### PR TITLE
add missing contact fax

### DIFF
--- a/local.config.yml
+++ b/local.config.yml
@@ -83,6 +83,7 @@ metadata:
     postalcode: 48149
     country: Germany
     phone: +xx-xxx-xxx-xxxx
+    fax: +xx-xxx-xxx-xxxx
     email: you@example.org
     url: Contact URL
     hours: Hours of Service


### PR DESCRIPTION
Latest version of pygeoapi requires `.metadata.contact.fax` in the config file